### PR TITLE
Updated configCompatibilityVersion to a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+[markdownlint](https://dlaa.me/markdownlint/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.7.5] - 2019-09-17
+
+### Changes in 1.7.5
+
+- Changed `configCompatibilityVersion` field in `GET /version` endpoint to be
+a string rather than an integer.  When it was specified as an integer, this 
+was a mistake in the original release.  NOTE: this will require that client
+code be regenerated.
+

--- a/senzing-rest-api.yaml
+++ b/senzing-rest-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Senzing REST API
-  version: "1.7.0"
+  version: "1.7.5"
   description: >-
     This is the Senzing REST API.  It describes the REST interface
     to Senzing API functions available via REST.  It leverages the
@@ -1402,8 +1402,7 @@ components:
           description: >-
             The build date for the underlying runtime native Senzing API.
         configCompatibilityVersion:
-          type: integer
-          format: int32
+          type: string
           description: >-
             The configuration compatibility version for the underlying runtime
             native Senzing API.


### PR DESCRIPTION
Modified SzVersionInfo schema definition so that `configCompatabilityVersion` is a string instead of an integer so it can represent semantic versions.